### PR TITLE
Improve sidebar responsiveness with relative units and media queries

### DIFF
--- a/reservas/static/css/custom.css
+++ b/reservas/static/css/custom.css
@@ -4,6 +4,10 @@ body, html {
     font-family: 'Roboto', sans-serif;
 }
 
+:root {
+    --sidebar-width: 15rem;
+}
+
 /* Estructura principal */
 .wrapper {
     display: flex;
@@ -14,7 +18,7 @@ body, html {
 
 /* Estilo del sidebar */
 .sidebar {
-    width: 240px;
+    width: var(--sidebar-width);
     background-color: #2c3e50;
     padding-top: 30px;
     padding-left: 20px;
@@ -31,7 +35,7 @@ body, html {
 }
 
 .sidebar-hidden {
-    transform: translateX(-240px);
+    transform: translateX(calc(-1 * var(--sidebar-width)));
 }
 
 .sidebar img {
@@ -63,7 +67,7 @@ body, html {
 .main-content {
     flex-grow: 1;
     padding: 20px;
-    margin-left: 240px;
+    margin-left: var(--sidebar-width);
     background-color: #ecf0f1;
     transition: margin-left 0.3s ease;
     overflow: hidden;
@@ -71,6 +75,24 @@ body, html {
 
 .sidebar-hidden + .main-content {
     margin-left: 0;
+}
+
+@media (max-width: 768px) {
+    .sidebar {
+        transform: translateX(calc(-1 * var(--sidebar-width)));
+    }
+
+    .sidebar.sidebar-open {
+        transform: translateX(0);
+    }
+
+    .main-content {
+        margin-left: 0;
+    }
+
+    #toggle-sidebar {
+        display: block;
+    }
 }
 
 /* Estilo de contenedores generales */
@@ -474,6 +496,7 @@ button:hover {
     border-radius: 5px;
     cursor: pointer;
     transition: background-color 0.3s ease;
+    display: none;
 }
 
 #toggle-sidebar:hover {


### PR DESCRIPTION
## Summary
- Replace fixed sidebar width and main content margin with rem-based CSS variable
- Introduce responsive media query to collapse sidebar and adjust layout on small screens
- Hide toggle button by default and reveal it on narrow viewports

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a8d5dd67483309413dc06e1e78156